### PR TITLE
[#13][WIP] Default Letter Overrides

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -11,7 +11,9 @@ Rails.configuration.to_prepare do
     def default_letter
       return nil if message_type == 'followup'
       "4982 Bilgi Edinme Hakkı Kanunu gereğince bilgi veya belge istemim " \
-      "aşağıda belirtilmiştir. Gereğini arz ederim."
+      "aşağıda belirtilmiştir. Gereğini arz ederim." \
+      "\n\n\n\n\n\n\n" \
+      "Başvuruma e-postayla cevap almak istiyorum."
     end
   end
 

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -7,6 +7,14 @@
 #
 Rails.configuration.to_prepare do
 
+  OutgoingMessage.class_eval do
+    def default_letter
+      return nil if message_type == 'followup'
+      "4982 Bilgi Edinme Hakkı Kanunu gereğince bilgi veya belge istemim " \
+      "aşağıda belirtilmiştir. Gereğini arz ederim."
+    end
+  end
+
   User.class_eval do
     validates :identity_card_number,
               :format => {


### PR DESCRIPTION
Fixes #13 

Can't do much about the extra `\n` added between the custom sign-off and "Yours faithfully". They're added elsewhere in a place not so easy to customise.

![screen shot 2016-05-11 at 10 56 11](https://cloud.githubusercontent.com/assets/282788/15177240/fe9de52c-1766-11e6-97ae-d9b341cda00e.png)

Thread https://groups.google.com/a/mysociety.org/forum/#!topic/alaveteli/f7hYACZivLc
